### PR TITLE
Take 3 on fixing the session token bug.

### DIFF
--- a/lib/http_adapter/angular.js
+++ b/lib/http_adapter/angular.js
@@ -4,6 +4,7 @@
 
     var context = typeof exports !== 'undefined' ? exports : window;
     var Promise = context.Promise || require('bluebird');
+    var SESSION_COOKIE_NAME_REGEX = /(?:^| )S=/;
 
     AngularAdapter.$inject = ['$http', '$document'];
     function AngularAdapter($http, $document) {
@@ -19,23 +20,33 @@
     };
 
     AngularAdapter.prototype.getSessionToken = function() {
-        return getCookieValueByName('S', this._$document[0].cookie);
-    };
+        var cookie = this._$document[0].cookie;
 
-    var getCookieValueByName = function(name, cookie) {
         // Note: Read from the cookie directly to ensure that it isn't outdated.
         if (!cookie.length) {
             return null;
         }
 
-        start = cookie.indexOf(name + "=");
+        var found = cookie.match(SESSION_COOKIE_NAME_REGEX);
+
+        if (!found) {
+            return null;
+        }
+
+        var start = found.index;
 
         if (-1 == start) {
             return null;
         }
 
-        start = start + name.length + 1;
-        end = cookie.indexOf(";", start);
+        start += 2;
+
+        // Regex includes leading space, so account for it.
+        if (found[0].charAt(0) === ' ') {
+            start++;
+        }
+
+        var end = cookie.indexOf(";", start);
 
         if (-1 == end) {
             end = cookie.length;

--- a/lib/wrappers/angular.js
+++ b/lib/wrappers/angular.js
@@ -15,8 +15,8 @@
         // and the same instance will be passed around through the Angular app.
         module.factory('taggedApi', taggedApiFactory);
 
-        taggedApiFactory.$inject = ['$http', '$document'];
-        function taggedApiFactory($http, $document) {
+        taggedApiFactory.$inject = ['$http', '$document', '$q'];
+        function taggedApiFactory($http, $document, $q) {
             var angularAdapter = new TaggedApi.AngularAdapter($http, $document);
 
             var api = new TaggedApi('/api/', {

--- a/test/unit/lib/http_adapter/angular_test.js
+++ b/test/unit/lib/http_adapter/angular_test.js
@@ -13,7 +13,7 @@ describe('Angular Adapter', function() {
         };
         this.$document = [
             {
-                cookie: 'foo=bar;S=test_session_token'
+                cookie: 'foo=bar; S=test_session_token'
             }
         ];
         this.adapter = new AngularAdapter(this.$http, this.$document);
@@ -74,6 +74,18 @@ describe('Angular Adapter', function() {
             this.$document[0].cookie = 'S=updated_session_token';
             var sessionToken = this.adapter.getSessionToken();
             sessionToken.should.equal('updated_session_token');
+        });
+
+        it('does not choke on very short cookie names', function() {
+            this.$document[0].cookie = 'SS=not_the_session_cookie; S=updated_session_token';
+            var sessionToken = this.adapter.getSessionToken();
+            sessionToken.should.equal('updated_session_token');
+        });
+
+        it('returns null if no session token is found', function() {
+            this.$document[0].cookie = 'SS=not_the_session_cookie; foo=bar';
+            var sessionToken = this.adapter.getSessionToken();
+            expect(sessionToken).to.be.null;
         });
     });
 });


### PR DESCRIPTION
Ensures that the `S` cookie is read properly by checking for a leading space or beginning-of-line before the `S` in the document cookie.